### PR TITLE
Update travis CI config - use go 1.11.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-  - 1.9
+  - "1.11.x"
 
 script:
   - make


### PR DESCRIPTION
CI is failing.
CoreDNS has an update of miek/dns that requires upgrade of go 
