### PR TITLE
bump-up Go version to 1.11.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-  - 1.9
+  - "1.11.x"
 
 script:
   - make

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ COVEROUT = cover.out
 GOFMTCHECK = test -z `gofmt -l -s -w *.go | tee /dev/stderr`
 GOTEST = go test -v
 COVER = $(GOTEST) -coverprofile=$(COVEROUT) -covermode=atomic -race
+GOPATH?=$(HOME)/go
 
 all: get fmt test
 
@@ -15,7 +16,19 @@ fmt:
 
 .PHONY: get
 get:
-	go get -v
+	@ # Not vendoring these, so external plugins compile, avoiding:
+	@ # cannot use c (type *"github.com/mholt/caddy".Controller) as type
+	@ # *"github.com/coredns/coredns/vendor/github.com/mholt/caddy".Controller like errors.
+	(cd $(GOPATH)/src/github.com/mholt/caddy 2>/dev/null              && git checkout -q master 2>/dev/null || true)
+	(cd $(GOPATH)/src/github.com/miekg/dns 2>/dev/null                && git checkout -q master 2>/dev/null || true)
+	(cd $(GOPATH)/src/github.com/prometheus/client_golang 2>/dev/null && git checkout -q master 2>/dev/null || true)
+	go get -u github.com/mholt/caddy
+	go get -u github.com/miekg/dns
+	go get -u github.com/prometheus/client_golang/prometheus/promhttp
+	go get -u github.com/prometheus/client_golang/prometheus
+	(cd $(GOPATH)/src/github.com/mholt/caddy              && git checkout -q v0.11.1)
+	(cd $(GOPATH)/src/github.com/miekg/dns                && git checkout -q v1.1.1)
+	(cd $(GOPATH)/src/github.com/prometheus/client_golang && git checkout -q v0.9.1)
 
 .PHONY: test
 test:


### PR DESCRIPTION
- move to go 11.2 for compatibility with CoreDNS