### PR TITLE
Fixed graceful reload for the plugin

### DIFF
--- a/alternate.go
+++ b/alternate.go
@@ -16,6 +16,7 @@ type Alternate struct {
 	Next     plugin.Handler
 	rules    map[int]rule
 	original bool // At least one rule has "original" flag
+	handlers []HandlerWithCallbacks
 }
 
 type rule struct {

--- a/setup.go
+++ b/setup.go
@@ -51,6 +51,7 @@ func setup(c *caddy.Controller) error {
 		if err != nil {
 			return plugin.Error("alternate", err)
 		}
+		a.handlers = append(a.handlers, handler)
 
 		for _, rcode := range rcodes {
 			a.rules[rcode] = rule{original: original, handler: handler}
@@ -65,18 +66,9 @@ func setup(c *caddy.Controller) error {
 		return a
 	})
 
-	c.OnStartup(func() error {
-		for _, r := range a.rules {
-			if err := r.handler.OnStartup(); err != nil {
-				return err
-			}
-		}
-		return nil
-	})
-
 	c.OnShutdown(func() error {
-		for _, r := range a.rules {
-			if err := r.handler.OnShutdown(); err != nil {
+		for _, handler := range a.handlers {
+			if err := handler.OnShutdown(); err != nil {
 				return err
 			}
 		}


### PR DESCRIPTION
With Corefile
```
.:53 {
	forward . 8.8.8.8
	alternate NXDOMAIN,SERVFAIL,REFUSED . 208.67.222.222
}
```
several consequent graceful reloads "killall -USR1 coredns" crash CoreDNS with:
```
[INFO] SIGUSR1: Reloading
--
[INFO] Reloading
[INFO] Reloading complete
panic: close of closed channel
 
goroutine 1935 [running]:
github.com/coredns/coredns/plugin/forward.(*Transport).connManager(0xc00060b320)
github.com/coredns/coredns/plugin/forward/persistent.go:79 +0x2e9
created by github.com/coredns/coredns/plugin/forward.(*Transport).Start
github.com/coredns/coredns/plugin/forward/persistent.go:140 +0x3f
```
Fixed issues:
1) With Corefile
```
.:53 {
	forward . 8.8.8.8
	alternate NXDOMAIN,SERVFAIL . 208.67.222.222
	alternate REFUSED . 1.1.1.1
}
```
setup.go will create rules:
rule[NXDOMAIN] = handler1, rule[SERVFAIL] = handler1, rule[REFUSED] = handler2
so on iterate rules handler1.OnShutdown() will be called twice which is wrong, this is fixed with creation separate handlers array;

2) SetProxy() already has healthcheck init inside, so call handler.OnStartup() on iterate rules is wrong, this is fixed with remove handler.OnStartup() calls at all.